### PR TITLE
Add simple grid simulator framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,38 @@
-# Hello World Python Template
+# Grid Simulator
 
-A simple Python project template that follows best practices and PEP8 guidelines.
+A simple framework to create power grid models, store them in a database and run load-flow calculations using [pandapower](https://pandapower.readthedocs.io/). A small Tkinter GUI allows entering buses and lines and viewing calculation results.
 
 ## Features
 
-- ✅ Type hints for better code clarity
-- ✅ Comprehensive docstrings
-- ✅ PEP8 compliant code style
-- ✅ Proper project structure
-- ✅ Main entry point pattern
-- ✅ Ready for testing and linting
-
-## Project Structure
-
-```
-.
-├── main.py           # Main application file
-├── requirements.txt  # Project dependencies
-├── README.md        # Project documentation
-├── .gitignore       # Git ignore file
-└── setup.cfg        # Configuration for linting tools
-```
+- Uses SQLite for persistent storage
+- Load-flow calculation engine based on pandapower
+- Tkinter GUI to add grid elements and run power flow
+- Minimal, single-file entry point (`main.py`)
 
 ## Installation
 
-1. Clone this repository
-2. Create a virtual environment:
+1. Create a virtual environment:
    ```bash
    python -m venv venv
    source venv/bin/activate  # On Windows: venv\Scripts\activate
    ```
-3. Install dependencies:
+2. Install dependencies:
    ```bash
    pip install -r requirements.txt
    ```
 
 ## Usage
 
-Run the application:
+Run the application with:
 ```bash
 python main.py
 ```
+A window opens where buses and lines can be added. Press **Run Load Flow** to perform a calculation and display the bus results.
 
 ## Development
 
-### Code Style
-
-This project follows PEP8 guidelines. To check code style:
-
-```bash
-# Install development dependencies
-pip install black flake8 mypy isort
-
-# Format code
-black main.py
-isort main.py
-
-# Check code style
-flake8 main.py
-
-# Type checking
-mypy main.py
-```
-
-### Testing
-
-```bash
-# Install pytest
-pip install pytest
-
-# Run tests (when you add them)
-pytest
-```
+The project follows basic PEP8 practices. Tools like `black`, `flake8` and `mypy` can be used for formatting and type checking.
 
 ## License
 
-This is a template project - feel free to use it as a starting point for your own projects.
+This example project is provided for demonstration purposes.

--- a/database.py
+++ b/database.py
@@ -1,0 +1,93 @@
+"""Simple SQLite database layer for storing grid data."""
+
+import sqlite3
+from typing import List, Tuple
+
+
+class GridDatabase:
+    """Manage grid data using an SQLite database."""
+
+    def __init__(self, path: str = "grid.db") -> None:
+        self.path = path
+        self.conn = sqlite3.connect(self.path)
+        self._create_tables()
+
+    def _create_tables(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS bus (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                vn_kv REAL NOT NULL
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS line (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                from_bus INTEGER NOT NULL,
+                to_bus INTEGER NOT NULL,
+                length_km REAL NOT NULL,
+                r_ohm_per_km REAL NOT NULL,
+                x_ohm_per_km REAL NOT NULL,
+                c_nf_per_km REAL NOT NULL,
+                max_i_ka REAL NOT NULL,
+                FOREIGN KEY(from_bus) REFERENCES bus(id),
+                FOREIGN KEY(to_bus) REFERENCES bus(id)
+            )
+            """
+        )
+        self.conn.commit()
+
+    def add_bus(self, name: str, vn_kv: float) -> int:
+        cur = self.conn.cursor()
+        cur.execute("INSERT INTO bus (name, vn_kv) VALUES (?, ?)", (name, vn_kv))
+        self.conn.commit()
+        return cur.lastrowid
+
+    def add_line(
+        self,
+        from_bus: int,
+        to_bus: int,
+        length_km: float,
+        r_ohm_per_km: float,
+        x_ohm_per_km: float,
+        c_nf_per_km: float,
+        max_i_ka: float,
+    ) -> int:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO line (
+                from_bus, to_bus, length_km, r_ohm_per_km,
+                x_ohm_per_km, c_nf_per_km, max_i_ka
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                from_bus,
+                to_bus,
+                length_km,
+                r_ohm_per_km,
+                x_ohm_per_km,
+                c_nf_per_km,
+                max_i_ka,
+            ),
+        )
+        self.conn.commit()
+        return cur.lastrowid
+
+    def get_buses(self) -> List[Tuple[int, str, float]]:
+        cur = self.conn.cursor()
+        cur.execute("SELECT id, name, vn_kv FROM bus")
+        return cur.fetchall()
+
+    def get_lines(
+        self,
+    ) -> List[Tuple[int, int, int, float, float, float, float, float]]:
+        cur = self.conn.cursor()
+        cur.execute(
+            "SELECT id, from_bus, to_bus, length_km, r_ohm_per_km, x_ohm_per_km, c_nf_per_km, max_i_ka FROM line"
+        )
+        return cur.fetchall()

--- a/engine.py
+++ b/engine.py
@@ -1,0 +1,48 @@
+"""Grid calculation engine using pandapower."""
+
+from typing import Any
+
+import pandapower as pp
+
+from database import GridDatabase
+
+
+class GridCalculator:
+    """Build and calculate power flow using pandapower."""
+
+    def __init__(self, db: GridDatabase) -> None:
+        self.db = db
+        self.net = pp.create_empty_network()
+
+    def build_network(self) -> None:
+        """Construct the pandapower network from database entries."""
+        for bus_id, name, vn_kv in self.db.get_buses():
+            pp.create_bus(self.net, vn_kv=vn_kv, name=name, index=bus_id)
+
+        for (
+            line_id,
+            from_bus,
+            to_bus,
+            length_km,
+            r_ohm_per_km,
+            x_ohm_per_km,
+            c_nf_per_km,
+            max_i_ka,
+        ) in self.db.get_lines():
+            pp.create_line_from_parameters(
+                self.net,
+                from_bus,
+                to_bus,
+                length_km=length_km,
+                r_ohm_per_km=r_ohm_per_km,
+                x_ohm_per_km=x_ohm_per_km,
+                c_nf_per_km=c_nf_per_km,
+                max_i_ka=max_i_ka,
+                name=str(line_id),
+            )
+
+    def run_powerflow(self) -> Any:
+        """Execute a power flow calculation and return results."""
+        self.build_network()
+        pp.runpp(self.net)
+        return self.net.res_bus

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,112 @@
+"""Tkinter GUI for grid data input and load flow results."""
+
+import tkinter as tk
+from tkinter import ttk
+from tkinter import messagebox
+
+from database import GridDatabase
+from engine import GridCalculator
+
+
+class GridApp:
+    """Main application window."""
+
+    def __init__(self, root: tk.Tk, db: GridDatabase) -> None:
+        self.root = root
+        self.db = db
+        self.root.title("Grid Simulator")
+
+        self._build_widgets()
+
+    def _build_widgets(self) -> None:
+        notebook = ttk.Notebook(self.root)
+        notebook.pack(fill="both", expand=True)
+
+        self.bus_frame = ttk.Frame(notebook)
+        self.line_frame = ttk.Frame(notebook)
+        self.result_frame = ttk.Frame(notebook)
+
+        notebook.add(self.bus_frame, text="Buses")
+        notebook.add(self.line_frame, text="Lines")
+        notebook.add(self.result_frame, text="Results")
+
+        # Bus inputs
+        ttk.Label(self.bus_frame, text="Name").grid(row=0, column=0, sticky=tk.W)
+        ttk.Label(self.bus_frame, text="Voltage (kV)").grid(
+            row=1, column=0, sticky=tk.W
+        )
+        self.bus_name = ttk.Entry(self.bus_frame)
+        self.bus_vn_kv = ttk.Entry(self.bus_frame)
+        self.bus_name.grid(row=0, column=1)
+        self.bus_vn_kv.grid(row=1, column=1)
+        ttk.Button(self.bus_frame, text="Add Bus", command=self.add_bus).grid(
+            row=2, column=0, columnspan=2
+        )
+
+        # Line inputs
+        labels = [
+            "From Bus ID",
+            "To Bus ID",
+            "Length (km)",
+            "R (ohm/km)",
+            "X (ohm/km)",
+            "C (nF/km)",
+            "Max I (kA)",
+        ]
+        self.line_entries = []
+        for i, lbl in enumerate(labels):
+            ttk.Label(self.line_frame, text=lbl).grid(row=i, column=0, sticky=tk.W)
+            entry = ttk.Entry(self.line_frame)
+            entry.grid(row=i, column=1)
+            self.line_entries.append(entry)
+        ttk.Button(self.line_frame, text="Add Line", command=self.add_line).grid(
+            row=len(labels), column=0, columnspan=2
+        )
+
+        ttk.Button(
+            self.result_frame, text="Run Load Flow", command=self.run_powerflow
+        ).pack()
+        self.text = tk.Text(self.result_frame, height=10, width=50)
+        self.text.pack(fill="both", expand=True)
+
+    def add_bus(self) -> None:
+        name = self.bus_name.get()
+        try:
+            vn_kv = float(self.bus_vn_kv.get())
+        except ValueError:
+            messagebox.showerror("Input Error", "Voltage must be a number")
+            return
+        self.db.add_bus(name, vn_kv)
+        self.bus_name.delete(0, tk.END)
+        self.bus_vn_kv.delete(0, tk.END)
+
+    def add_line(self) -> None:
+        try:
+            values = [float(e.get()) for e in self.line_entries]
+        except ValueError:
+            messagebox.showerror("Input Error", "All line parameters must be numbers")
+            return
+        self.db.add_line(*[int(values[0]), int(values[1])], *values[2:])
+        for e in self.line_entries:
+            e.delete(0, tk.END)
+
+    def run_powerflow(self) -> None:
+        calc = GridCalculator(self.db)
+        try:
+            res_bus = calc.run_powerflow()
+        except Exception as exc:  # broad except to show message
+            messagebox.showerror("Error", str(exc))
+            return
+        self.text.delete("1.0", tk.END)
+        self.text.insert(tk.END, str(res_bus))
+
+
+def main() -> None:
+    root = tk.Tk()
+    db = GridDatabase()
+    app = GridApp(root, db)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -1,48 +1,8 @@
 #!/usr/bin/env python3
-"""
-A simple Hello World application template following Python best practices.
+"""Entry point for the Grid Simulator application."""
 
-This module serves as a template for Python projects, demonstrating proper
-structure, type hints, docstrings, and PEP8 compliance.
-"""
-
-from typing import Optional
-
-
-def greet(name: Optional[str] = None) -> str:
-    """
-    Generate a greeting message.
-
-    Args:
-        name: The name to greet. If None, greets the world.
-
-    Returns:
-        A greeting message string.
-
-    Examples:
-        >>> greet()
-        'Hello, World!'
-        >>> greet("Alice")
-        'Hello, Alice!'
-    """
-    if name is None:
-        return "Hello, World!"
-    return f"Hello, {name}!"
-
-
-def main() -> None:
-    """
-    Main entry point of the application.
-    
-    This function orchestrates the program execution and handles
-    any necessary setup or cleanup.
-    """
-    # Print the default greeting
-    print(greet())
-    
-    # Example of greeting with a name
-    print(greet("Python Developer"))
+from gui import main as gui_main
 
 
 if __name__ == "__main__":
-    main()
+    gui_main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandapower
+pandas


### PR DESCRIPTION
## Summary
- overhaul project to implement a small grid simulator
- add SQLite `GridDatabase` layer
- add pandapower-based `GridCalculator`
- implement Tkinter GUI to add buses/lines and run power flow
- update entrypoint and documentation

## Testing
- `pip install black > /tmp/pip.log && tail -n 20 /tmp/pip.log`
- `black *.py > /tmp/black.log && tail -n 20 /tmp/black.log`


------
https://chatgpt.com/codex/tasks/task_e_68442975a8048332bf48e94e268c30f6