### PR TITLE
Add element tables summary function

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -1,6 +1,6 @@
 """Grid calculation engine using pandapower."""
 
-from typing import Any
+from typing import Any, List
 
 import pandapower as pp
 
@@ -46,3 +46,30 @@ class GridCalculator:
         self.build_network()
         pp.runpp(self.net)
         return self.net.res_bus
+
+
+def element_tables(net: pp.pandapowerNet) -> str:
+    """Return formatted tables of common grid elements in *net*.
+
+    Elements include lines, transformers, generators, static generators,
+    loads and external grids. Only non-empty tables are included in the
+    returned string.
+    """
+
+    element_map = {
+        "Lines": "line",
+        "Transformers": "trafo",
+        "Generators": "gen",
+        "Static Generators": "sgen",
+        "Loads": "load",
+        "External Grids": "ext_grid",
+    }
+
+    tables: List[str] = []
+    for title, attr in element_map.items():
+        df = getattr(net, attr, None)
+        if df is not None and not df.empty:
+            tables.append(f"{title}\n{df.to_string()}\n")
+
+    return "\n".join(tables)
+

--- a/tests/test_element_tables.py
+++ b/tests/test_element_tables.py
@@ -1,0 +1,10 @@
+import engine
+from examples import create_example_grid
+
+
+def test_element_tables_example_grid():
+    net = create_example_grid()
+    output = engine.element_tables(net)
+    assert "Lines" in output
+    assert "Loads" in output
+    assert "External Grids" in output


### PR DESCRIPTION
## Summary
- expose a new `element_tables` helper for printing pandapower network elements
- test that the helper returns lines, loads and external grid tables

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844323ce7208332bdcded357f809e8e